### PR TITLE
Add project statistics graphs

### DIFF
--- a/web/apps/labelstudio/src/components/BarChart/BarChart.jsx
+++ b/web/apps/labelstudio/src/components/BarChart/BarChart.jsx
@@ -1,0 +1,46 @@
+import { useRef, useEffect } from 'react';
+import { select, scaleBand, scaleLinear, axisLeft, axisBottom, max } from 'd3';
+
+export const BarChart = ({ data, width = 400, height = 200 }) => {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const svg = select(ref.current);
+    svg.selectAll('*').remove();
+
+    const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+    const x = scaleBand()
+      .domain(data.map(d => d.label))
+      .range([margin.left, width - margin.right])
+      .padding(0.1);
+
+    const y = scaleLinear()
+      .domain([0, max(data, d => d.count) || 0])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    svg
+      .append('g')
+      .selectAll('rect')
+      .data(data)
+      .join('rect')
+      .attr('x', d => x(d.label))
+      .attr('y', d => y(d.count))
+      .attr('height', d => y(0) - y(d.count))
+      .attr('width', x.bandwidth())
+      .attr('fill', '#3182bd');
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(axisBottom(x));
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(axisLeft(y));
+  }, [data, height, width]);
+
+  return <svg ref={ref} width={width} height={height} />;
+};

--- a/web/apps/labelstudio/src/components/index.js
+++ b/web/apps/labelstudio/src/components/index.js
@@ -10,3 +10,4 @@ export { Spinner } from "./Spinner/Spinner";
 export { ToggleItems } from "./ToggleItems/ToggleItems";
 export { VersionNotifier } from "./VersionNotifier/VersionNotifier";
 export { Pagination } from "./Pagination/Pagination";
+export { BarChart } from "./BarChart/BarChart";

--- a/web/apps/labelstudio/src/pages/ProjectStats/ProjectStats.jsx
+++ b/web/apps/labelstudio/src/pages/ProjectStats/ProjectStats.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { Block } from '../../utils/bem';
+import { useAPI } from '../../providers/ApiProvider';
+import { useProject } from '../../providers/ProjectProvider';
+import { Spinner } from '../../components/Spinner/Spinner';
+import { BarChart } from '../../components/BarChart/BarChart';
+
+export const ProjectStats = () => {
+  const api = useAPI();
+  const { project } = useProject();
+  const [summary, setSummary] = useState(null);
+
+  useEffect(() => {
+    if (!project?.id) return;
+    api.callApi('dataSummary', { params: { pk: project.id } }).then(setSummary);
+  }, [project]);
+
+  if (!summary) return (
+    <Block name="project-stats"><Spinner size={64} /></Block>
+  );
+
+  const labels = [];
+  for (const [_, data] of Object.entries(summary.created_labels || {})) {
+    for (const [label, count] of Object.entries(data)) {
+      const found = labels.find(l => l.label === label);
+      if (found) found.count += count;
+      else labels.push({ label, count });
+    }
+  }
+
+  const tasksData = [
+    { label: 'Completed', count: project.finished_task_number || 0 },
+    { label: 'Remaining', count: (project.task_number || 0) - (project.finished_task_number || 0) },
+  ];
+
+  return (
+    <Block name="project-stats">
+      <h2>Project Statistics</h2>
+      <h3>Task Progress</h3>
+      <BarChart data={tasksData} />
+      <h3>Labels Distribution</h3>
+      <BarChart data={labels} />
+    </Block>
+  );
+};
+
+ProjectStats.title = 'Statistics';
+ProjectStats.path = '/stats';

--- a/web/apps/labelstudio/src/pages/Projects/Projects.jsx
+++ b/web/apps/labelstudio/src/pages/Projects/Projects.jsx
@@ -10,6 +10,7 @@ import { Block, Elem } from "../../utils/bem";
 import { CreateProject } from "../CreateProject/CreateProject";
 import { DataManagerPage } from "../DataManager/DataManager";
 import { SettingsPage } from "../Settings";
+import { ProjectStats } from "../ProjectStats/ProjectStats";
 import { EmptyProjectsList, ProjectsList } from "./ProjectsList";
 import { useAbortController } from "@humansignal/core";
 import "./Projects.scss";
@@ -154,6 +155,7 @@ ProjectsPage.routes = ({ store }) => [
     pages: {
       DataManagerPage,
       SettingsPage,
+      ProjectStats,
     },
   },
 ];


### PR DESCRIPTION
## Summary
- add BarChart component using d3
- show project stats page with task progress and label distribution
- expose statistics page under project routes

## Testing
- `pre-commit` *(fails: command not found)*
- `yarn lint` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68777e1a07748326b2e456c9d454c2e9