### PR TITLE
Fix version retrieval fallback for local testing

### DIFF
--- a/label_studio/__init__.py
+++ b/label_studio/__init__.py
@@ -1,12 +1,24 @@
 """This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 """
 import importlib.metadata
+from pathlib import Path
+import re
 
 # Package name
 package_name = 'label-studio'
 
 # Package version
-__version__ = importlib.metadata.metadata(package_name).get('version')
+try:
+    __version__ = importlib.metadata.metadata(package_name).get("version")
+except importlib.metadata.PackageNotFoundError:
+    # Fallback to version from local pyproject if package metadata is missing
+    try:
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        text = pyproject.read_text()
+        match = re.search(r"^version\s*=\s*['\"](.+?)['\"]", text, re.MULTILINE)
+        __version__ = match.group(1) if match else "0.0.0"
+    except Exception:
+        __version__ = "0.0.0"
 
 # pypi info
 __latest_version__ = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,8 @@ mock = ">=5.1.0"
 moto = ">=4.2.6"
 requests-mock = "1.12.1"
 factory-boy = "^3.3.3"
+boto3 = "1.39.3"
+botocore = ">=1.39.3,<2.0.0"
 
 [tool.poetry.group.build.dependencies]
 twine = ">=6.1.0"


### PR DESCRIPTION
## Summary
- avoid failing tests by reading `pyproject.toml` for version info when package metadata is missing
- include boto3 and botocore in test dependencies

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'boto3')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687886b66cc08326a440451d3c26bed5